### PR TITLE
mkey: hardcode region for CTR v1

### DIFF
--- a/mkey.py
+++ b/mkey.py
@@ -63,6 +63,7 @@ class mkey_generator():
                 "addout": 0x1657,
             },
             "v1": {
+                "regions": [0, 1, 2],
                 "hmac_file": "ctr_%02x.bin",
             },
             "v2": {


### PR DESCRIPTION
It was missed in the previous commit, but this one handles regions too.