### PR TITLE
wiiu: fix v0 mkey generation

### DIFF
--- a/mkey.py
+++ b/mkey.py
@@ -75,9 +75,9 @@ class mkey_generator():
             "traits": ["big-endian"],
             "algorithms": ["v0", "v2"],
             "v0": {
-                "poly": 0xEDBA6320,
+                "poly": 0x1EDC6F41,
                 "xorout": 0xAAAA,
-                "addout": 0x1657,
+                "addout": 0x226C,
             },
             "v2": {
                 "traits": ["no-versions"],

--- a/source/mkey.c
+++ b/source/mkey.c
@@ -127,9 +127,9 @@ static const mkey_props _props[sizeof(mkey_devices) / sizeof(*mkey_devices)] =
         .algorithms = 0b00101,
         .big_endian = true,
         .v0 = {
-            .poly = 0xEDBA6320,
+            .poly = 0x1EDC6F41,
             .xorout = 0xAAAA,
-            .addout = 0x1657,
+            .addout = 0x226C,
         },
         .v2 = {
             .no_versions = true,


### PR DESCRIPTION
Apparently this has been wrong since forever and no one noticed